### PR TITLE
Add fade-in rise animation for main section

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -84,6 +84,9 @@ main {
     flex-direction: column;
     align-items: center;
     gap: 25px;
+    opacity: 0;
+    transform: translateY(20px);
+    animation: main-fade-in 0.8s ease-out forwards;
 }
 section {
     width: 100%;
@@ -93,6 +96,18 @@ section {
     gap: 20px;
     /* 锚点定位时，预留导航栏高度 */
     scroll-margin-top: 125px;
+}
+
+@keyframes main-fade-in {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 /* 按钮样式 */


### PR DESCRIPTION
## Summary
- add a fade-in, upward float animation to the main content area on load
- define keyframes to animate opacity and vertical position for the main element

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3667793548327b33d56f7aef897d8