### PR TITLE
🧪 Add unit tests for negotiateLocale

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -2,7 +2,7 @@
 // 首页重定向，根据 cookie / 浏览器语言 / 国家选择语言
 // 写入 host-only lang cookie（不带 Domain，SameSite=Lax），默认 30 天有效
 
-const SUPPORTED = ["zh-cn","zh-tw","en-us","ja-jp"];
+export const SUPPORTED = ["zh-cn","zh-tw","en-us","ja-jp"];
 const LANG_COOKIE = "lang";
 const COUNTRY_FALLBACK = {
     CN:"zh-cn", TW:"zh-tw", HK:"zh-tw", MO:"zh-tw", SG:"zh-cn", MY:"zh-cn",
@@ -17,7 +17,7 @@ function readLangCookie(req) {
     try { return decodeURIComponent(m[1]).toLowerCase(); } catch { return null; }
 }
 
-function negotiateLocale(acceptLang) {
+export function negotiateLocale(acceptLang) {
     if (!acceptLang) return null;
     const parts = acceptLang.split(",").map(seg => {
         const [tagRaw,qRaw] = seg.trim().split(";q=");

--- a/functions/index.test.mjs
+++ b/functions/index.test.mjs
@@ -1,0 +1,57 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { negotiateLocale } from './index.js';
+
+test('negotiateLocale', async (t) => {
+  await t.test('returns null for empty or null input', () => {
+    assert.strictEqual(negotiateLocale(null), null);
+    assert.strictEqual(negotiateLocale(''), null);
+  });
+
+  await t.test('returns exact match for supported languages', () => {
+    assert.strictEqual(negotiateLocale('zh-cn'), 'zh-cn');
+    assert.strictEqual(negotiateLocale('zh-tw'), 'zh-tw');
+    assert.strictEqual(negotiateLocale('en-us'), 'en-us');
+    assert.strictEqual(negotiateLocale('ja-jp'), 'ja-jp');
+  });
+
+  await t.test('is case-insensitive', () => {
+    assert.strictEqual(negotiateLocale('ZH-CN'), 'zh-cn');
+    assert.strictEqual(negotiateLocale('En-Us'), 'en-us');
+  });
+
+  await t.test('handles fallback to base language', () => {
+    // zh-hk should match zh-cn as it is the first zh-* in SUPPORTED
+    assert.strictEqual(negotiateLocale('zh-hk'), 'zh-cn');
+    // en-gb should match en-us
+    assert.strictEqual(negotiateLocale('en-gb'), 'en-us');
+  });
+
+  await t.test('respects q-values for ordering', () => {
+    assert.strictEqual(negotiateLocale('ja-jp;q=0.5, en-us;q=0.9'), 'en-us');
+    assert.strictEqual(negotiateLocale('zh-tw;q=0.8, zh-cn;q=0.9'), 'zh-cn');
+  });
+
+  await t.test('handles multiple languages with fallbacks', () => {
+    // fr-FR is not supported, should fall back to en-US
+    assert.strictEqual(negotiateLocale('fr-fr, en-us;q=0.8'), 'en-us');
+    // zh-HK falls back to zh-CN which has higher priority than ja-JP
+    assert.strictEqual(negotiateLocale('zh-hk;q=0.9, ja-jp;q=0.8'), 'zh-cn');
+  });
+
+  await t.test('returns null when no match is found', () => {
+    assert.strictEqual(negotiateLocale('fr-fr, de-de'), null);
+    assert.strictEqual(negotiateLocale('unknown'), null);
+  });
+
+  await t.test('handles malformed input gracefully', () => {
+    assert.strictEqual(negotiateLocale('zh-cn;q=invalid'), 'zh-cn');
+    assert.strictEqual(negotiateLocale(';q=0.8'), null);
+    assert.strictEqual(negotiateLocale(','), null);
+    assert.strictEqual(negotiateLocale('zh-cn, , en-us'), 'zh-cn');
+  });
+
+  await t.test('handles extra whitespace', () => {
+    assert.strictEqual(negotiateLocale('  en-us  ,  zh-cn;q=0.5  '), 'en-us');
+  });
+});


### PR DESCRIPTION
This PR adds unit tests for the `negotiateLocale` function in `functions/index.js`.

### Changes:
- Modified `functions/index.js` to export `SUPPORTED` and `negotiateLocale`.
- Created `functions/index.test.mjs` using the built-in Node.js test runner.

### Scenarios Covered:
- Null or empty `Accept-Language` header.
- Exact matches for supported locales (`zh-cn`, `zh-tw`, `en-us`, `ja-jp`).
- Case-insensitivity (e.g., `ZH-CN`).
- Quality values (`q`) for prioritized language selection.
- Fallback to base language (e.g., `zh-hk` -> `zh-cn`).
- No match found (returns `null`).
- Malformed header strings.
- Extra whitespace handling.

All tests pass using `node --test functions/index.test.mjs`.

---
*PR created automatically by Jules for task [6187958375071431797](https://jules.google.com/task/6187958375071431797) started by @CQMHV*